### PR TITLE
removed YouTube and Google Translate shortcuts

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -8,14 +8,6 @@ function main() {
 }
 
 function findCapitalInput({ hostname, pathname }) {
-  // YouTube
-  if (hostname == "www.youtube.com" && ["/", "/watch"].includes(pathname))
-    return $("input#search");
-
-  // Google Translate
-  if (hostname == "translate.google.com" && pathname == "/")
-    return $("#source");
-
   if (hostname == "www.thesaurus.com") return $("input[type='search']");
 
   return null;


### PR DESCRIPTION
For:
* There is an extension for Google Translate
https://github.com/ShionFujie/google_translate_shortcuts
* YouTube has the default shortcut